### PR TITLE
fix(antimetal-agent): remove kubernetes.io/version from labelSelectors

### DIFF
--- a/charts/antimetal-agent/Chart.yaml
+++ b/charts/antimetal-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: antimetal-agent
-description: A Helm chart for Kubernetes
+description: A Helm chart to deploy the Antimetal agent
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "v0.1.1"
 home: https://antimetal.com

--- a/charts/antimetal-agent/templates/_helpers.tpl
+++ b/charts/antimetal-agent/templates/_helpers.tpl
@@ -45,9 +45,6 @@ Selector labels
 {{- define "antimetal-agent.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "antimetal-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
label selectors fields are immutable so whenever you try to upgrade the chart to a new version, it will fail to apply, preventing upgrades. You would have to uninstall and reinstall the chart.