### PR TITLE
feat(antimetal-agent): bump appVersion to v0.2.0 & add pprof config

### DIFF
--- a/charts/antimetal-agent/Chart.yaml
+++ b/charts/antimetal-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: antimetal-agent
 description: A Helm chart to deploy the Antimetal agent
 type: application
-version: 0.1.2
-appVersion: "v0.1.1"
+version: 0.2.0
+appVersion: "v0.2.0"
 home: https://antimetal.com

--- a/charts/antimetal-agent/templates/deployment.yaml
+++ b/charts/antimetal-agent/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             {{- else }}
             - --metrics-bind-address=0
             {{- end }}
+            {{- if .Values.pprof.enable }}
+            - --pprof-address={{ printf ":%s" .Values.pprof.port }}
+            {{- end }}
           env:
             - name: KUBERNETES_NODE_IP
               valueFrom:

--- a/charts/antimetal-agent/values.yaml
+++ b/charts/antimetal-agent/values.yaml
@@ -84,6 +84,12 @@ metrics:
   #   # The secret must be a kubernetes.io/tls secret type.
   #   secretRef: ""
 
+pprof:
+  # Enable the pprof server to expose profiling data.
+  # It is not recommended to enable this in production environments.
+  enable: false
+  port: "6060"
+
 # Annotations to add to agent pod.
 podAnnotations: {}
 # Additional labels to add to agent pod.


### PR DESCRIPTION
v0.2.0 introduces the --prof-address flag which can be used to enable the pprof server. Add an option in the values.yaml to enable it. The default is disabled.