### PR TITLE
feat(antimetal-agent): upgrade to v0.3.0

### DIFF
--- a/charts/antimetal-agent/Chart.yaml
+++ b/charts/antimetal-agent/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: antimetal-agent
 description: A Helm chart to deploy the Antimetal agent
 type: application
-version: 0.2.0
-appVersion: "v0.2.0"
+version: 0.3.0
+appVersion: "v0.3.1"
 home: https://antimetal.com

--- a/charts/antimetal-agent/templates/daemonset.yaml
+++ b/charts/antimetal-agent/templates/daemonset.yaml
@@ -1,11 +1,10 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "antimetal-agent.fullname" . }}
   labels:
     {{- include "antimetal-agent.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       {{- include "antimetal-agent.selectorLabels" . | nindent 6 }}
@@ -55,6 +54,12 @@ spec:
             {{- range  $key, $value := $providerData }}
             - --kubernetes-provider-{{ $.Values.provider.name }}-{{ $key }}={{ $value }}
             {{- end }}
+            {{- if .Values.performance.enable }}
+            - --enable-performance-collectors
+            {{- end }}
+            {{- if .Values.performance.exporters.otel.enable }}
+            - --enable-otel
+            {{- end }}
             {{- if .Values.metrics.enable }}
             - --metrics-bind-address={{ include "antimetal-agent.metricsServerPort" . | printf ":%s" }}
             - --metrics-secure={{ default false .Values.metrics.secure }}
@@ -78,8 +83,25 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            {{- with .Values.extraEnvs }}
-            {{- toYaml . | nindent 12 }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_PROC
+              value: /host/proc
+            - name: HOST_SYS
+              value: /host/sys
+            - name: HOST_DEV
+              value: /host/dev
+            - name: HOST_ETC
+              value: /host/etc
+            - name: HOST_VAR
+              value: /host/var
+            - name: HOST_CGROUP
+              value: /host/cgroup
+            {{- range .Values.extraEnvs }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
             {{- end }}
           envFrom:
             - secretRef:
@@ -102,9 +124,29 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or (and .Values.metrics.enable .Values.metrics.secure .Values.metrics.tls) .Values.extraVolumes }}
           volumeMounts:
-            {{- with .Values.metrics.tls }}
+            - name: data
+              mountPath: /var/lib/antimetal
+            - name: proc
+              mountPath: /host/proc
+              readOnly: true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: dev
+              mountPath: /host/dev
+              readOnly: true
+            - name: machine-id
+              mountPath: /host/etc/machine-id
+              readOnly: true
+            - name: dbus
+              mountPath: /host/var/lib/dbus
+              readOnly: true
+            - name: cgroup
+              mountPath: /host/cgroup
+              readOnly: true
+            {{- if and .Values.metrics.enable .Values.metrics.secure }}
+            {{- with required "metrics.tls must be set" .Values.metrics.tls }}
             - name: metrics-tls
               mountPath: /etc/antimetal-agent/tls
               readOnly: true
@@ -113,17 +155,41 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or (and .Values.metrics.enable .Values.metrics.secure .Values.metrics.tls) .Values.extraVolumes }}
       volumes:
-        {{- with .Values.metrics.tls }}
+        - name: data
+          emptyDir: {}
+        - name: proc
+          hostPath:
+            path: /proc
+            type: Directory
+        - name: sys
+          hostPath:
+            path: /sys
+            type: Directory
+        - name: dev
+          hostPath:
+            path: /dev
+            type: Directory
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
+        - name: dbus
+          hostPath:
+            path: /var/lib/dbus
+        - name: cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        {{- if and .Values.metrics.enable .Values.metrics.secure }}
+        {{- with required "metrics.tls must be set" .Values.metrics.tls }}
         - name: metrics-tls
           secret:
-            secretName: {{ required "tls.secretRef must be set" .secretRef }}
+            secretName: {{ required "metrics.tls.secretRef must be set" .secretRef }}
         {{- end }}
-        {{- with .Values.extraVolumes }}
+        {{- end }}
+        {{- with .Values.extravolumes }}
           {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/antimetal-agent/values.yaml
+++ b/charts/antimetal-agent/values.yaml
@@ -13,8 +13,6 @@ image:
 
 imagePullSecrets: []
 
-replicaCount: 1
-
 # Address of the Antimetal API server.
 apiAddress: ""
 # Token to use for the agent to authenticate with the Antimetal API.
@@ -51,6 +49,17 @@ provider:
     # account-id: ""
     # region: ""
     # cluster-name: ""
+
+performance:
+  enable: false
+  exporters:
+    otel:
+      enable: false
+      # Use OTEL & OTLP env vars in extraEnvs to configure Opentelemetry settings
+      # At minimum you will need OTEL_EXPORTER_OTLP_ENDPOINT.
+      # Refer to https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/
+      # and https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/
+      # for full configuration.
 
 serviceAccount:
   # Specifies whether a service account for the agent should be created
@@ -101,6 +110,8 @@ extraEnvsFrom: []
 
 # Agent pod security context.
 podSecurityContext:
+  fsGroup: 65532
+  runAsUser: 65532
   runAsNonRoot: true
 
 # Agent container security context.


### PR DESCRIPTION
- Upgrades antimetal-agent to v0.3.1 which enables new functionality. See [Antimetal Agent Changelog](https://github.com/antimetal/system-agent/releases/tag/v0.3.1) for details.

- Upgrade agent Deployment to Daemonset

- Update default fsGroup and user for pod security context

- Add host system directories (/proc, /sys, /dev, etc.) as volume mounts to the agent container